### PR TITLE
Update: Use originContext as create conversation params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 !/src/claude/
 
 .secrets
+.vscode

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@octokit/rest": "^21.1.1",
         "@octokit/webhooks-types": "^7.6.1",
         "node-fetch": "^3.3.2",
-        "wakumo-ai-sdk-js": "^0.1.2",
+        "wakumo-ai-sdk-js": "^0.1.4",
         "zod": "^3.24.4",
       },
       "devDependencies": {
@@ -294,7 +294,7 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
-    "wakumo-ai-sdk-js": ["wakumo-ai-sdk-js@0.1.2", "", { "dependencies": { "axios": "^1.6.8", "ws": "^8.16.0", "yargs": "^17.7.2" }, "bin": { "wakumo-ai": "dist/cli.js" } }, "sha512-MQE0MRsOYs9egaMWuhKDkbCgnjT95aCev37Pz/oXcE1ldULsH3Z8HY/Sjsg+mbCIOu71xEpaTj8aHyTt7qg9NQ=="],
+    "wakumo-ai-sdk-js": ["wakumo-ai-sdk-js@0.1.4", "", { "dependencies": { "axios": "^1.6.8", "ws": "^8.16.0", "yargs": "^17.7.2" }, "bin": { "wakumo-ai": "dist/cli.js" } }, "sha512-yDFI7TRgqgP6jA7W/YmCPEqwdI/FFbrpwio4nrE7ucRYboBCdRUyJ3buZgv6ct4H+BB8+ebynjme8OAnSeQjnA=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@octokit/rest": "^21.1.1",
     "@octokit/webhooks-types": "^7.6.1",
     "node-fetch": "^3.3.2",
-    "wakumo-ai-sdk-js": "^0.1.2",
+    "wakumo-ai-sdk-js": "^0.1.4",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/src/entrypoints/index.ts
+++ b/src/entrypoints/index.ts
@@ -101,18 +101,38 @@ async function run() {
     }
     const client = new WakumoAIClient(initParams);
 
-    // Create a conversation with the final prompt
-    const conversation = await client.conversation.create(prompt);
-
-    // Compose the comment message
-    const message = `This issue is being processed by Wakumo AI.\nConversation ID: ${conversation.id}\nVisit the Wakumo AI app for more details.`;
-
-    // Post a comment back to the issue/PR
-    await octokit.rest.issues.createComment({
+    const initialMessage = `This issue is being processed by Wakumo AI.\nConversation will be created shortly.`;
+    const commentResp = await octokit.rest.issues.createComment({
       owner,
       repo,
       issue_number: issueNumber,
-      body: message,
+      body: initialMessage,
+    });
+    const commentId = commentResp.data.id;
+
+    const originContext = {
+      source: {
+        name: 'github',
+        org: owner,
+        resource: repo,
+      },
+      type: payload.issue ? 'issue_comment' : 'pull_request_comment',
+      id: issueNumber.toString(),
+      sub_id: commentId.toString(),
+    };
+    const conversation = await client.conversation.create(
+      prompt,
+      [],
+      [],
+      originContext
+    );
+
+    const updatedMessage = `This issue is being processed by Wakumo AI.\nConversation ID: ${conversation.id}\nVisit the Wakumo AI app for more details.`;
+    await octokit.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      body: updatedMessage,
     });
   } catch (error) {
     core.setFailed(`Action failed: ${error}`);


### PR DESCRIPTION
## Summary

Pass `originContext` parameter when creating conversations to link GitHub issues/PRs with Wakumo AI conversations for better traceability.

## Changes

- Upgraded `wakumo-ai-sdk-js` from `0.1.2` to `0.1.4`
- Create initial placeholder comment before conversation creation
- Pass `originContext` with GitHub metadata (org, repo, issue/PR number, comment ID)
- Update comment with conversation ID after creation

## originContext Structure

```typescript
const originContext = {
  source: { name: 'github', org: owner, resource: repo },
  type: payload.issue ? 'issue_comment' : 'pull_request_comment',
  id: issueNumber.toString(),
  sub_id: commentId.toString(),
};
```

